### PR TITLE
Modify the "env_file" param

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -45,7 +45,7 @@ services:
     volumes:
       - ./mysql:/var/lib/mysql
     env_file:
-      - ./docker/.env:./.env
+      - .env
     environment:
       MYSQL_DATABASE: "${DB_NAME}"
       MYSQL_USER: "${DB_USER}"


### PR DESCRIPTION
If follow the READNE  will show: “ERROR: Couldn't find env file”, because only the file needs to be specified, no mapping is required.